### PR TITLE
:whale: Add Docker Compose for Backing Services

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+## Local Development
+
+To run the Polaron API on your local machine, you will need to have an FTP Server and MongoDB instance configured. With [Docker Compose](https://docs.docker.com/compose/) installed, run the following command:
+
+```bash
+docker-compose up
+```
+
+This will start both of these services in docker containers, ready for use by Polaron. Ensure that the environment that you are running Polaron has the following variables set:
+
+```
+MONGO_CONNECTION_URL=mongodb://localhost:27017
+FTP_HOST=127.0.0.1
+FTP_PORT=2222
+FTP_USERNAME=polaron
+FTP_PASSWORD=pass
+```
+
+Now you're ready to `npm start` 🎉

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.7'
+
+services:
+  mongodb:
+    image: mongo:4
+    ports:
+      - '27017:27017'
+
+  # connect with
+  # sftp -P 2222 polaron@0.0.0.0
+  #
+  # password = pass
+  SFTP:
+    image: atmoz/sftp
+    ports:
+      - '2222:22'
+    command: polaron:pass:1001


### PR DESCRIPTION
This PR pulls the `docker-compose.yml` file from the [DevBox repository](https://github.com/polaronjs/DevBox) into the api repository so that you can easily spin up local containers for Mongo and FTP to run the API.

Additionally, I added a `CONTRIBUTING.md` file to document how to spin up the API. I put this in a new file so that the README can be a public facing document that is catered to consumers, since the intention is to package the API as an NPM package.